### PR TITLE
add ability to not rebuild aide database while doing testing

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,6 +3,12 @@
 # Attributes:: default
 #
 
+# Use test mode to disable rebuilding the aide database every run.
+# This is desinged to save you time while working on building
+# your cookbook that relays on this one. Return to false when
+# rolling out to any non development enviorment.
+default["aide"]["testmode"] = "false"
+
 case platform
 when "centos","redhat","fedora"
   default["aide"]["binary"] = "/usr/sbin/aide"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,5 +23,7 @@ end
 script "generate_database" do
   action :nothing
   interpreter "bash"
-  code "#{node['aide']['binary']} #{node['aide']['extra_parameters']} --init"
+  unless node['aide']['testmode'] == "true"
+    code "#{node['aide']['binary']} #{node['aide']['extra_parameters']} --init"
+  end
 end


### PR DESCRIPTION
I found when doing tests with vagrant/berkshelf that without this code, it was taking 15 to 30 seconds for aide to rebuild its database each time.

Chef Run complete in 17.088299961 seconds
vs
Chef Run complete in 0.735597031 seconds
