### PR TITLE
Paremeterized report_url in aide.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ as in the default AIDE config file.
 * `node["aide"]["paths"]` - A dictionary of paths for AIDE to inspect and
 how to handle them, pre-populated as in the default AIDE config file.
 
+* `node["aide"]["report_url"]` - Where to send the output.  Defaults to "stdout". 
+See the AIDE documentation for other options.
+
 Usage
 =====
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -8,6 +8,7 @@
 # your cookbook that relays on this one. Return to false when
 # rolling out to any non development enviorment.
 default["aide"]["testmode"] = "false"
+default["aide"]["report_url"] = "stdout"
 
 case platform
 when "centos","redhat","fedora"

--- a/templates/default/aide.conf.erb
+++ b/templates/default/aide.conf.erb
@@ -3,7 +3,7 @@ database=file:@@{DBDIR}/aide.db.gz
 database_out=file:@@{DBDIR}/aide.db.gz
 gzip_dbout=yes
 verbose=5
-report_url=stdout
+report_url=<%= node["aide"]["report_url"] %>
 
 <% node["aide"]["macros"].each do |name,definition| -%>
 <%= name %> = <%= definition %>


### PR DESCRIPTION
Allows sending output to a file or syslog easily.  Default remains unchanged.
