### PR TITLE
Update metadata.rb

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,6 +6,7 @@ maintainer_email    "elliot.kendall@ucsf.edu"
 license             "BSD"
 version             "0.1.2"
 
-supports            "centos", "ubuntu"
+supports            "centos"
+supports            "ubuntu"
 
 recipe              "aide", "Installs and configures AIDE HIDS"


### PR DESCRIPTION
According to https://docs.chef.io/cookbook_repo.html#settings:
The "supports" setting: "To specify more than one platform, use more than one supports field, once for each platform."
There should be more than one "supports" setting for multiple platforms, and that would include different versions of the same platform.  This causes the current issue with chef-dk-0.4.0-1 in Berkshelf:
Ridley::Errors::FromFileParserError Could not parse `/var/tmp/chef-aide/metadata.rb': 'ubuntu' did not contain a valid operator or a valid version string.
